### PR TITLE
Mesh2 hmain axis fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@
   - heightfield2shading: new option to generate a normal map.
     (Bertrand Kerautret [#415](https://github.com/DGtal-team/DGtalTools/pull/415))
   - mesh2heightfield: automatic object placement and improved usage.
-    (Bertrand Kerautret [#415](https://github.com/DGtal-team/DGtalTools/pull/415))
+    (Bertrand Kerautret & Florian Delconte [#429](https://github.com/DGtal-team/DGtalTools/pull/415))
 
 - *build*
   - New cmake option (DGTAL_RANDOMIZED_BUILD_THRESHOLD) to set the

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@
   - heightfield2shading: new option to generate a normal map.
     (Bertrand Kerautret [#415](https://github.com/DGtal-team/DGtalTools/pull/415))
   - mesh2heightfield: automatic object placement and improved usage.
-    (Bertrand Kerautret & Florian Delconte [#429](https://github.com/DGtal-team/DGtalTools/pull/415))
+    (Bertrand Kerautret & Florian Delconte [#429](https://github.com/DGtal-team/DGtalTools/pull/429))
 
 - *build*
   - New cmake option (DGTAL_RANDOMIZED_BUILD_THRESHOLD) to set the


### PR DESCRIPTION
*Thanks a lot for contributing to DGtalTools, before submitting your PR, please fill up the description and make sure that all checkboxes are checked.*

# PR Description

The calculated principal directions was not good. (mesh2heightfield.cpp, function `getMainDirsCoVar(...)`)
The problem comes from the covariance matrix. 
I took the way to calculate the covariance matrix from "computeCovarianceMatrix" from PCL api. (centroid.hpp, l.180)
The main directions are good now.

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
